### PR TITLE
Avoid duplicate HTTP requests in downloader

### DIFF
--- a/EzFlasher/GetDownloads.vb
+++ b/EzFlasher/GetDownloads.vb
@@ -17,7 +17,7 @@ Public Class GetDownloads
         Dim respRead As New StreamReader(httpResp.GetResponseStream())
         Dim respResult As String = respRead.ReadToEnd
         If returnUrlOnly = True Then
-            Dim respUrl = httpReq.GetResponse().ResponseUri.AbsoluteUri
+            Dim respUrl = httpResp.ResponseUri.AbsoluteUri
             Return respUrl
         End If
         Return respResult


### PR DESCRIPTION
## Summary
- stop `makeHTTPRequest` from issuing a second HTTP request when only the final URL is required

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a798618c4c832982c20f9f8d88b59a