### PR TITLE
Add tests for GetDownloads.getFileName

### DIFF
--- a/EzFlasher.Tests/EzFlasher.Tests.vbproj
+++ b/EzFlasher.Tests/EzFlasher.Tests.vbproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DD37E4B6-44F4-4370-BCBD-EB5A64F7C75E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>EzFlasher.Tests</RootNamespace>
+    <AssemblyName>EzFlasher.Tests</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <OutputPath>bin\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <DefineTrace>true</DefineTrace>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+    <ProjectReference Include="..\EzFlasher\EzFlasher.vbproj">
+      <Project>{1E462D8C-74B1-480A-A607-B309B41A5F60}</Project>
+      <Name>EzFlasher</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GetDownloadsTests.vb" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+</Project>

--- a/EzFlasher.Tests/GetDownloadsTests.vb
+++ b/EzFlasher.Tests/GetDownloadsTests.vb
@@ -1,0 +1,25 @@
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+<TestClass>
+Public Class GetDownloadsTests
+    <TestMethod>
+    Public Sub GetFileName_WithQuery_ReturnsFileName()
+        Dim getter As New GetDownloads()
+        Dim result As String = getter.getFileName("http://example.com/file.zip?retrieve_file=1")
+        Assert.AreEqual("file.zip", result)
+    End Sub
+
+    <TestMethod>
+    Public Sub GetFileName_WithoutQuery_ReturnsFileName()
+        Dim getter As New GetDownloads()
+        Dim result As String = getter.getFileName("http://example.com/file.zip")
+        Assert.AreEqual("file.zip", result)
+    End Sub
+
+    <TestMethod>
+    Public Sub GetFileName_WithPath_ReturnsFileName()
+        Dim getter As New GetDownloads()
+        Dim result As String = getter.getFileName("http://example.com/path/to/file.zip")
+        Assert.AreEqual("file.zip", result)
+    End Sub
+End Class

--- a/EzFlasher.sln
+++ b/EzFlasher.sln
@@ -3,12 +3,18 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "EzFlasher", "EzFlasher\EzFlasher.vbproj", "{1E462D8C-74B1-480A-A607-B309B41A5F60}"
 EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "EzFlasher.Tests", "EzFlasher.Tests\EzFlasher.Tests.vbproj", "{DD37E4B6-44F4-4370-BCBD-EB5A64F7C75E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {DD37E4B6-44F4-4370-BCBD-EB5A64F7C75E}.Debug|x86.ActiveCfg = Debug|AnyCPU
+                {DD37E4B6-44F4-4370-BCBD-EB5A64F7C75E}.Debug|x86.Build.0 = Debug|AnyCPU
+                {DD37E4B6-44F4-4370-BCBD-EB5A64F7C75E}.Release|x86.ActiveCfg = Release|AnyCPU
+                {DD37E4B6-44F4-4370-BCBD-EB5A64F7C75E}.Release|x86.Build.0 = Release|AnyCPU
 		{1E462D8C-74B1-480A-A607-B309B41A5F60}.Debug|x86.ActiveCfg = Debug|x86
 		{1E462D8C-74B1-480A-A607-B309B41A5F60}.Debug|x86.Build.0 = Debug|x86
 		{1E462D8C-74B1-480A-A607-B309B41A5F60}.Release|x86.ActiveCfg = Release|x86


### PR DESCRIPTION
## Summary
- add EzFlasher.Tests project with MSTest setup
- cover GetDownloads.getFileName for URLs with and without query strings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a79bb04c2c8329ae83b850e6dbbe22