### PR TITLE
fix: correct PhilZ recovery comment

### DIFF
--- a/EzFlasher/Form1.vb
+++ b/EzFlasher/Form1.vb
@@ -192,7 +192,7 @@ Public Class Form1
             Select Case ComboBox1.SelectedIndex
                 Case 0 'TWRP for KK
                     recovFile &= "twrp_kk.img"
-                Case 1 'Philz for KK
+                Case 1 'PhilZ for KK
                     recovFile &= "philz_kk.img"
                 Case 2 'CWM for KK
                     recovFile &= "cwm_kk.img"


### PR DESCRIPTION
## Summary
- correct recovery selection comment to match PhilZ naming

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden on repositories)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a79bacd8b08329b3730d754ad0ac0e